### PR TITLE
Update to express-handlebars 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "express-handlebars": "^2.0.0"
+    "express-handlebars": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
This also to avoid the warning that old versions of express-handlebars will throw due to graceful-fs being deprecated for newer releases of node.
