### PR TITLE
Add support for multiple viewPath

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import handlebars from 'express-handlebars';
+import { existsSync } from 'fs';
 
 class TemplateGenerator {
   constructor(opts) {
@@ -17,13 +18,54 @@ class TemplateGenerator {
       return;
     }
 
-    let templatePath = join(this.viewPath, mail.data.template + this.extName);
+    let templatePath = '';
+    if (Array.isArray(this.viewPath)) {
+      for(var index in this.viewPath) {
+        var tempPath = join(this.viewPath[index], mail.data.template + this.extName);    
+        if (existsSync(tempPath)) {
+          templatePath = tempPath
+          break;
+        }
+      }
+      if (templatePath==='') {
+        var notFound = new Error("ENOENT: no such file or directory, open '"+this.viewPath.join("','")+"'");
+        notFound.code ="ENOENT"
+        notFound.errno = -4058
+        notFound.path = this.viewPath
+        notFound.syscall = 'open'
+        throw notFound;
+      }
+    } else {
+        templatePath = path.join(
+          this.viewPath,
+          mail.data.template + this.extName
+        );
+    }
+
     let textTemplatePath = '';
     if (mail.data.text_template) {
-      textTemplatePath = join(
-        this.viewPath,
-        mail.data.text_template + this.extName,
-      );
+      if (Array.isArray(this.viewPath)) {
+        for(var index in this.viewPath) {
+          var tempPath = join(this.viewPath[index], mail.data.template + this.extName);    
+          if (existsSync(tempPath)) {
+            textTemplatePath = tempPath
+            break;
+          }
+        }
+        if (textTemplatePath==='') {
+          var notFound = new Error("ENOENT: no such file or directory, open '"+this.viewPath.join("','")+"'");
+          notFound.code ="ENOENT"
+          notFound.errno = -4058
+          notFound.path = this.viewPath
+          notFound.syscall = 'open'
+          throw notFound;  
+        }
+      } else {
+          textTemplatePath = path.join(
+            this.viewPath,
+            mail.data.template + this.extName
+          );
+      }
     }
 
     mail.data.html = await this.viewEngine.renderView(


### PR DESCRIPTION
With this addition the viewPath will accept an array of strings instead of just a single string.

- Behaves as expected using strings, no change in behaviour for traditional use
- If an array is sent it will loop the array and use first file found as the template
- If using array and no file is found a normal error is served just as before